### PR TITLE
Add searchTerm parameter to getTeams

### DIFF
--- a/cmd/server/handlers.go
+++ b/cmd/server/handlers.go
@@ -244,10 +244,17 @@ func GetTeamsHandler(w http.ResponseWriter, r *http.Request) {
 	queryParams := r.URL.Query()
 	leagueId, _ := strconv.Atoi(queryParams.Get("leagueId"))
 	season, _ := strconv.Atoi(queryParams.Get("season"))
+	searchTerm := queryParams.Get("searchTerm")
 
 	var teams []apifootball.Team
 	var err error
-	teams, err = dao.GetTeamsForLeagueAndSeason(leagueId, season)
+
+	if searchTerm != "" {
+		teams, err = dao.GetTeams(db.GetTeamsFilter{SearchTerm: searchTerm})
+	} else {
+		teams, err = dao.GetTeamsForLeagueAndSeason(leagueId, season)
+	}
+
 	if err != nil {
 		log.Println(err)
 	}

--- a/internal/db/dao.go
+++ b/internal/db/dao.go
@@ -52,7 +52,8 @@ type GetFixuresFilter struct {
 }
 
 type GetTeamsFilter struct {
-	Country string
+	Country    string
+	SearchTerm string
 }
 
 func NewPostgresDAO(db *sql.DB) Top90DAO {

--- a/internal/db/dao_test.go
+++ b/internal/db/dao_test.go
@@ -143,6 +143,11 @@ func TestGetTeams(t *testing.T) {
 
 	teams, _ = dao.GetTeams(GetTeamsFilter{Country: "lkjlk"})
 	assert.Equal(t, len(teams), 0)
+
+	teams, err = dao.GetTeams(GetTeamsFilter{SearchTerm: "team1"})
+	assert.NilError(t, err)
+	assert.Equal(t, len(teams), 1)
+	assert.Equal(t, teams[0].Id, 1)
 }
 
 func assertEqual(t *testing.T, actual top90.Goal, expected top90.Goal) {

--- a/internal/db/query_constructor.go
+++ b/internal/db/query_constructor.go
@@ -68,12 +68,17 @@ func getFixturesWhereClause(filter GetFixuresFilter, args []any) (string, []any)
 func getTeamsWhereClause(filter GetTeamsFilter, args []any) (string, []any) {
 	whereClause := ""
 
+	whereClause = whereClause + "$1"
+	args = append(args, "TRUE")
+
 	if filter.Country != "" {
-		whereClause = whereClause + fmt.Sprintf(" %s = $1", teamColumns.Country)
+		whereClause = whereClause + fmt.Sprintf(" AND %s = $%d", teamColumns.Country, len(args)+1)
 		args = append(args, filter.Country)
-	} else {
-		whereClause = whereClause + " $1"
-		args = append(args, "TRUE")
+	}
+
+	if filter.SearchTerm != "" {
+		whereClause = whereClause + fmt.Sprintf(" AND %s ILIKE $%d", teamColumns.Name, len(args)+1)
+		args = append(args, fmt.Sprintf("%%%s%%", filter.SearchTerm))
 	}
 
 	return whereClause, args


### PR DESCRIPTION
Can now make request like `/teams?searchTerm=abc` and get results that contain the search term 