### PR TITLE
Skip posts with long titles

### DIFF
--- a/internal/poller/poller.go
+++ b/internal/poller/poller.go
@@ -125,8 +125,12 @@ func (poller *GoalPoller) ingestPosts(posts []reddit.RedditPost, options Options
 
 func (poller *GoalPoller) ingest(wg *sync.WaitGroup, post reddit.RedditPost) {
 	defer wg.Done()
-
 	log.Println("\nprocessing...", post.Data.Id)
+
+	if len(post.Data.Title) > 120 {
+		log.Println("skipping processing. post title does not look like the title of a goal post.")
+		return
+	}
 
 	sourceUrl := poller.getSourceUrl(post)
 	log.Println("final source url: ", "[", sourceUrl, "]")


### PR DESCRIPTION
When a post title is longer than ~120 characters, that means it probably is not a goal post titles are in the format `QPR [1] - 0 Middlesbrough - Andre Dozzell great goal` which is much shorter than that.

This hopes to prevent storing videos of things that are not actually goals.