### PR TITLE
Improve ad filtering

### DIFF
--- a/internal/scrape/chromedp.go
+++ b/internal/scrape/chromedp.go
@@ -101,6 +101,12 @@ func (s chromeDpScraper) getVideoSourceNetwork(ctx context.Context, url string) 
 func getSource(nodes []*cdp.Node, url string) string {
 	for _, node := range nodes {
 		sourceUrl := node.AttributeValue("src")
+
+		id := node.AttributeValue("id")
+		if (strings.HasPrefix(url, "https://streamin.one") || strings.HasPrefix(url, "https://streamin.me")) && id == "video" {
+			return sourceUrl
+		}
+
 		// Sometimes streamff sources are a relative path
 		if strings.HasPrefix(url, "https://streamff") && strings.HasPrefix(sourceUrl, "/uploads") {
 			sourceUrl = "https://streamff.com" + sourceUrl


### PR DESCRIPTION
If we can directly get the video with id="video", return that one since that is the one that is not an ad